### PR TITLE
Fixed a key lookup failure.

### DIFF
--- a/sphinxswagger/writer.py
+++ b/sphinxswagger/writer.py
@@ -92,6 +92,7 @@ class SwaggerTranslator(nodes.SparseNodeVisitor):
         # END TODO
 
         default = 'default'
+        responses[default] = {}
         for child in node[idx].children:
             if isinstance(child, nodes.paragraph):
                 p = _render_paragraph(child)


### PR DESCRIPTION
If you run `sphinx-build -b swagger srs dest`, you get this error:

```
Exception occurred:
  File "c:\users\moigagoo\projects\venvs\sloth-ci\lib\site-packages\sphinxswagger\writer.py", line 126, in depart_desc
    responses[default].setdefault('headers', {})
KeyError: 'default'
```

This happens because `responses` is an empty dict, it has no `"default"` key.

This tiny patch fixes it.
