### PR TITLE
Add a setuptools task

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -16,6 +16,11 @@ Configuration
 -------------
 This extension contains a few useful configuration values:
 
+:swagger_description:
+   Sets the description of the application in the generated swagger file.
+   If this is not set, then the "description" value in ``html_theme_options``
+   will be used if it is set.
+
 :swagger_file:
    Sets the name of the generated swagger file.  The file is always
    generated in the sphinx output directory -- usually *build/sphinx/swagger*.

--- a/README.rst
+++ b/README.rst
@@ -9,12 +9,33 @@ Usage
 
 1. Enable the extension in your *conf.py* by adding ``'sphinxswagger'``
    to the ``extensions`` list
-2. Run the ``swagger`` builder (e.g., ``setup.py build_sphinx -b swagger``)
+2. Run the ``swagger`` builder (e.g., ``setup.py swagger``)
 3. Use the generated *swagger.json*
+
+Setuptools Command
+------------------
+This library installs a new command named **swagger** that is available
+from the *setup.py* utility.  It runs sphinx to generate the swagger
+output file.  It is similar to running ``sphinx-build -b swagger`` except
+that it has access to your packages metadata so you don't have to
+configure it in two places!
+
+**This is the recommend approach for using this package.**
+
+You can configure the output file name in your project's *setup.cfg* in
+the ``[swagger]`` section::
+
+   [swagger]
+   output-file = static/swagger.json
+
+This makes it easier to include it directly into your built artifact
+by adding it as ``package_data`` in *setup.py*.  Remember to add it to
+your *MANIFEST.in* as well.
 
 Configuration
 -------------
-This extension contains a few useful configuration values:
+This extension contains a few useful configuration values that can be
+set from within the sphinx configuration file.
 
 :swagger_description:
    Sets the description of the application in the generated swagger file.

--- a/docs/history.rst
+++ b/docs/history.rst
@@ -1,6 +1,10 @@
 Release History
 ===============
 
+`Next Release`_
+---------------
+- Add swagger_description configuration value.
+
 `0.0.2`_ (2017 Mar 2)
 ---------------------
 - Added support for JSON responses.

--- a/docs/history.rst
+++ b/docs/history.rst
@@ -3,7 +3,9 @@ Release History
 
 `Next Release`_
 ---------------
-- Add swagger_description configuration value.
+- Rewrite to be more resilient to changes in the underlying
+  docutil structure.
+- Added ``swagger`` setup command.
 
 `0.0.2`_ (2017 Mar 2)
 ---------------------

--- a/docs/history.rst
+++ b/docs/history.rst
@@ -1,8 +1,8 @@
 Release History
 ===============
 
-`Next Release`_
----------------
+`0.0.3`_ (2017 Mar 22)
+----------------------
 - Rewrite to be more resilient to changes in the underlying
   docutil structure.
 - Added ``swagger`` setup command.
@@ -15,6 +15,7 @@ Release History
 ----------------------
 - Initial release with simple Sphinx writer+builder.
 
-.. _Next Release: https://github.com/dave-shawley/sphinx-swagger/compare/0.0.2...HEAD
+.. _Next Release: https://github.com/dave-shawley/sphinx-swagger/compare/0.0.3...HEAD
+.. _0.0.3: https://github.com/dave-shawley/sphinx-swagger/compare/0.0.2...0.0.3
 .. _0.0.2: https://github.com/dave-shawley/sphinx-swagger/compare/0.0.1...0.0.2
 .. _0.0.1: https://github.com/dave-shawley/sphinx-swagger/compare/0.0.0...0.0.1

--- a/sphinxswagger/__init__.py
+++ b/sphinxswagger/__init__.py
@@ -17,6 +17,7 @@ def setup(app):
     app.add_builder(builder.SwaggerBuilder)
     app.add_config_value('swagger_file', 'swagger.json', True)
     app.add_config_value('swagger_license', {'name': 'Proprietary'}, True)
+    app.add_config_value('swagger_description', '', True)
     app.connect('build-finished', writer.write_swagger_file)
 
     return {'version': __version__}

--- a/sphinxswagger/__init__.py
+++ b/sphinxswagger/__init__.py
@@ -1,4 +1,4 @@
-version_info = (0, 0, 2)
+version_info = (0, 0, 3)
 __version__ = '.'.join(str(v) for v in version_info)
 
 

--- a/sphinxswagger/builder.py
+++ b/sphinxswagger/builder.py
@@ -2,7 +2,7 @@ import docutils.io
 
 from sphinx import builders
 
-from . import writer
+from . import document, writer
 
 
 class SwaggerBuilder(builders.Builder):
@@ -15,7 +15,7 @@ class SwaggerBuilder(builders.Builder):
 
     def prepare_writing(self, docnames):
         """Called before :meth:`write_doc`"""
-        self.swagger = writer.SwaggerDocument()
+        self.swagger = document.SwaggerDocument()
         self.writer = writer.SwaggerWriter(swagger_document=self.swagger)
 
     def write_doc(self, docname, doctree):

--- a/sphinxswagger/builder.py
+++ b/sphinxswagger/builder.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import docutils.io
 
 from sphinx import builders

--- a/sphinxswagger/command.py
+++ b/sphinxswagger/command.py
@@ -1,0 +1,68 @@
+from distutils import cmd, log
+import os.path
+
+from sphinx import application
+
+
+class BuildSwagger(cmd.Command):
+    description = 'Build a swagger definition from Sphinx docs'
+    user_options = [
+        ('config-dir=', 'c', 'configuration directory'),
+        ('output-file=', 'o', 'output file name'),
+        ('ignore-distinfo', 'u', 'ignore distribution metadata'),
+    ]
+    boolean_options = ['ignore-distinfo']
+
+    def initialize_options(self):
+        self.config_dir = None
+        self.output_file = None
+        self.ignore_distinfo = False
+
+    def finalize_options(self):
+        if self.config_dir is None:
+            self.config_dir = 'docs'
+        self.ensure_dirname('config_dir')
+        if self.config_dir is None:
+            self.config_dir = os.curdir
+            self.warning('Using {} as configuration directory',
+                         self.source_dir)
+        self.config_dir = os.path.abspath(self.config_dir)
+
+        if self.output_file is not None:
+            self.output_file = os.path.abspath(self.output_file)
+
+    def run(self):
+        build_cmd = self.get_finalized_command('build')
+        build_dir = os.path.join(os.path.abspath(build_cmd.build_base),
+                                 'swagger')
+        self.mkpath(build_dir)
+        doctree_dir = os.path.join(build_dir, 'doctrees')
+        self.mkpath(doctree_dir)
+
+        overrides = {}
+        if self.output_file is not None:
+            overrides['swagger_file'] = self.output_file
+
+        if not self.ignore_distinfo:
+            if self.distribution.get_description():
+                overrides['swagger_description'] = \
+                    self.distribution.get_description()
+            if self.distribution.get_license():
+                overrides['swagger_license.name'] = \
+                    self.distribution.get_license()
+            if self.distribution.get_version():
+                overrides['version'] = self.distribution.get_version()
+
+        app = application.Sphinx(
+            self.config_dir, self.config_dir, build_dir, doctree_dir,
+            'swagger', confoverrides=overrides)
+        app.build()
+
+    def warning(self, msg, *args):
+        self.announce(msg.format(*args), level=log.WARNING)
+
+    def info(self, msg, *args):
+        self.announce(msg.format(*args), level=log.INFO)
+
+    def debug(self, msg, *args):
+        self.announce(msg.format(*args), level=log.DEBUG)

--- a/sphinxswagger/document.py
+++ b/sphinxswagger/document.py
@@ -1,0 +1,92 @@
+try:
+    import http.client as http_client
+except ImportError:
+    import httplib as http_client
+
+
+class SwaggerDocument(object):
+
+    def __init__(self):
+        super(SwaggerDocument, self).__init__()
+        self._paths = {}
+
+    def get_document(self, config):
+        """
+        :param sphinx.config.Config config: project level configuration
+        :return: the swagger document as a :class:`dict`
+        :rtype: dict
+        """
+        info = {'title': config.project,
+                'description': config.swagger_description,
+                'license': config.swagger_license,
+                'version': config.version}
+        if not info['description'] and hasattr(config, 'html_theme_options'):
+            info['description'] = config.html_theme_options.get('description')
+
+        return {'swagger': '2.0',
+                'info': info,
+                'host': 'localhost:80',
+                'basePath': '/',
+                'paths': self._paths}
+
+    def add_endpoint(self, endpoint, debug_info=None):
+        """
+        Add a swagger endpoint document.
+
+        :param SwaggerEndpoint endpoint: the endpoint to add
+        :param dict debug_info: optional debug information to include
+            in the swagger definition
+
+        """
+        path_info = self._paths.setdefault(endpoint.uri_template, {})
+        if endpoint.method in path_info:
+            pass  # already gots this ... good this isn't
+        path_info[endpoint.method] = endpoint.generate_swagger()
+        if debug_info:
+            path_info[endpoint.method]['x-debug-info'] = debug_info
+
+
+class SwaggerEndpoint(object):
+
+    def __init__(self):
+        self.method = None
+        self.uri_template = None
+        self.summary = ''
+        self.description = ''
+        self.parameters = []
+        self.responses = {}
+
+    def add_request_headers(self, headers):
+        for name, description in headers.items():
+            self.parameters.append({
+                'name': name,
+                'description': description,
+                'in': 'header',
+                'type': 'string',
+            })
+
+    def add_response_codes(self, status_dict):
+        for code, info in status_dict.items():
+            swagger_rsp = self.responses.setdefault(code, {})
+            if not info['reason']:
+                try:
+                    code = int(code)
+                    info['reason'] = http_client.responses[code]
+                except (KeyError, TypeError, ValueError):
+                    info['reason'] = 'Unknown'
+
+            tokens = info['description'].split(maxsplit=2)
+            if tokens:
+                tokens[0] = tokens[0].title()
+            swagger_rsp['description'] = '{}\n\n{}'.format(
+                info['reason'], ' '.join(tokens)).strip()
+
+    def generate_swagger(self):
+        swagger = {'summary': self.summary, 'description': self.description}
+        if self.parameters:
+            swagger['parameters'] = self.parameters
+        if self.responses:
+            swagger['responses'] = self.responses
+        else:  # swagger requires at least one response
+            swagger['responses'] = {'default': {'description': ''}}
+        return swagger

--- a/sphinxswagger/writer.py
+++ b/sphinxswagger/writer.py
@@ -380,8 +380,8 @@ class SwaggerDocument(object):
         }
         try:
             info['description'] = config.html_theme_options['description']
-        except AttributeError:
-            pass
+        except (AttributeError, KeyError):
+            info['description'] = ''
         if config.swagger_license:
             info['license'] = config.swagger_license
 

--- a/sphinxswagger/writer.py
+++ b/sphinxswagger/writer.py
@@ -1,20 +1,12 @@
 from docutils import nodes, writers
-import copy
 import json
 import os.path
 import re
-try:
-    import http.client as http_client
-except ImportError:
-    import httplib as http_client
 
-from sphinx import addnodes
+from sphinxswagger import document
 
 
 URI_TEMPLATE_RE = re.compile(r'\(\?P<([^>]*)>.*\)')
-PARAMETER_RE = re.compile(r'(?P<name>[^ ]*)\s+'
-                          r'(\((?P<type>[^)]*)\))?\s*'
-                          r'--\s+(?P<description>.*)')
 
 
 def write_swagger_file(app, exception):
@@ -47,170 +39,345 @@ class SwaggerWriter(writers.Writer):
 class SwaggerTranslator(nodes.SparseNodeVisitor):
 
     def __init__(self, document, output_document):
+        """
+        :param docutils.nodes.document document:
+        :param sphinxswagger.document.Document output_document:
+        """
         nodes.NodeVisitor.__init__(self, document)  # assigns self.document
+        self.document = document  # tells pycharm the attributes type
+        document.reporter.report_level = document.reporter.DEBUG_LEVEL
         self._swagger_doc = output_document
+
+        self._current_node = None
+        self._endpoint = None
+
+    def debug(self, message, *args, **kwargs):
+        self.document.reporter.debug(message.format(*args, **kwargs),
+                                     base_node=self._current_node)
+
+    def info(self, message, *args, **kwargs):
+        self.document.reporter.info(message.format(*args, **kwargs),
+                                    base_node=self._current_node)
+
+    def warning(self, message, *args, **kwargs):
+        self.document.reporter.warning(message.format(*args, **kwargs),
+                                       base_node=self._current_node)
+
+    def error(self, message, *args, **kwargs):
+        self.document.reporter.error(message.format(*args, **kwargs),
+                                     base_node=self._current_node)
+
+    def _start_new_path(self, node):
+        """
+        :param sphinx.addnodes.desc node:
+        """
+        self._current_node = node
+        self._endpoint = document.SwaggerEndpoint()
+        self._endpoint.method = node['desctype']
+        self.info('processing {}', node['desctype'])
+
+    def _complete_current_path(self, node):
+        """
+        :param sphinx.addnodes.desc node:
+        """
+        assert self._current_node is node
+        self._swagger_doc.add_endpoint(self._endpoint,
+                                       _generate_debug_tree(node))
+        self._endpoint = None
         self._current_node = None
 
-    def warning(self, *args, **kwargs):
-        self.document.reporter.warning(*args, **kwargs)
-
-    def error(self, *args, **kwargs):
-        self.document.reporter.error(*args, **kwargs)
-
-    def reset_path_data(self, node):
-        self._current_node = node
-
     def visit_desc(self, node):
-        if isinstance(node, addnodes.desc) and node['domain'] == 'http':
-            self.reset_path_data(node)
+        if node['domain'] == 'http':
+            self._start_new_path(node)
+
+        if not self._endpoint:
+            raise nodes.SkipNode
 
     def depart_desc(self, node):
         """
         :param docutils.nodes.Element node:
         """
-        if node is not self._current_node:
+        if self._current_node is node:
+            self._complete_current_path(node)
             return
 
-        idx = node.first_child_matching_class(addnodes.desc_signature)
-        if idx is None:  # no detail about the signature, skip it
-            self._current_node = None
-            return
+    def visit_desc_signature(self, node):
+        """
+        Process a method signature.
 
-        desc_signature = node.children[idx]
-        url_template = _convert_url(desc_signature['path'])
-        paragraphs = []
-        responses = {'default': {}}
-        parameters = []
+        :param sphinx.addnodes.desc_signature node:
 
-        idx = node.first_child_matching_class(addnodes.desc_content)
-        if idx is None:  # no content, skip
-            return
+        """
+        self.debug('visiting {}: {!r}', node.__class__, node.attributes)
+        if node.parent is self._current_node:
+            # signature of the endpoint itself
+            self._endpoint.uri_template = _convert_url(node['path'])
 
-        # TODO remove this ... useful for debugging only
-        # debug_name = 'out-{}.json'.format(len(self._swagger_doc._paths))
-        # with open(debug_name, 'w') as f:
-        #     data = _generate_debug_tree(node)
-        #     data['signature'] = desc_signature['path']
-        #     data['url_template'] = url_template
-        #     json.dump(data, f, indent=2)
-        # END TODO
+    def visit_desc_content(self, node):
+        """
+        Process the method's description.
 
-        default = 'default'
-        for child in node[idx].children:
-            if isinstance(child, nodes.paragraph):
-                paragraphs.append(_render_paragraph(child))
+        :param sphinx.addnodes.desc_content node:
 
-            if isinstance(child, nodes.field_list):  # list of some sort
-                for field in child.children:
-                    # assumptions, assumptions, assumptions ...
-                    assert isinstance(field, nodes.field)
-                    assert isinstance(field[0], nodes.field_name)
-                    assert isinstance(field[1], nodes.field_body)
+        """
+        self.debug('visiting {}: {!r}', node.__class__, node.attributes)
+        if node.parent is self._current_node:
+            # description of the endpoint itself
+            walker = EndpointVisitor(self.document, self._endpoint)
+            node.walkabout(walker)
+            self._endpoint.description = '\n\n'.join(walker.description)
 
-                    name = field[0]
-                    if name.astext() == 'Response JSON Object':
-                        rsp = _render_response_information(field[1])
-                        if rsp is not None:
-                            responses.setdefault(default, {})
-                            responses[default].update(rsp)
 
-                    elif name.astext() == 'Response JSON Array of Objects':
-                        obj_def = _render_response_information(field[1])
-                        if obj_def is not None:
-                            responses.setdefault(default, {})
-                            responses[default].update({
-                                'description': obj_def['description'],
-                                'schema': {
-                                    'type': 'array',
-                                    'items': obj_def['schema'],
-                                }
-                            })
+class EndpointVisitor(nodes.SparseNodeVisitor):
+    """
+    Visits the content for a single endpoint.
+    """
 
-                    elif name.astext() == 'Request JSON Object':
-                        properties = {}
-                        for name, spec in _generate_parameters(field[1]):
-                            properties[name] = {
-                                'type': spec['type'],
-                                'description': spec['description']
-                            }
-                        parameters.append({'name': 'request-body',
-                                           'in': 'body',
-                                           'required': True,
-                                           'schema': {
-                                               'type': 'object',
-                                               'properties': properties,
-                                           }})
+    def __init__(self, document, endpoint):
+        """
+        :param docutils.nodes.document document:
+        :param sphinxswagger.document.SwaggerEndpoint endpoint:
+        """
+        nodes.SparseNodeVisitor.__init__(self, document)
+        self.document = document
+        self.endpoint = endpoint
+        self.description = []
 
-                    elif name.astext() == 'Status Codes':
-                        for code, _, desc in _generate_status_codes(field[1]):
-                            if default == 'default' and 200 <= int(code) < 300:
-                                d = responses.pop('default', {})
-                                responses[code] = d
-                                default = code
-                            responses.setdefault(code, {})
-                            responses[code]['description'] = desc
+    def visit_paragraph(self, node):
+        """
+        :param docutils.nodes.paragraph node:
+        """
+        if not self.endpoint.summary:  # first paragraph is the summary
+            self.endpoint.summary = node.astext()
+        else:  # others are description
+            visitor = ParagraphVisitor(self.document)
+            node.walkabout(visitor)
+            self.description.append(visitor.get_paragraph())
 
-                    elif name.astext() == 'Response Headers':
-                        responses[default].setdefault('headers', {})
-                        headers = responses[default]['headers']
-                        for name, spec in _generate_parameters(field[1]):
-                            headers[name] = spec
+    def visit_field(self, node):
+        """
+        :param docutils.nodes.field node:
+        """
+        idx = node.first_child_matching_class(nodes.field_name)
+        if idx is not None:
+            name_node = node[idx]
+            idx = node.first_child_matching_class(nodes.field_body)
+            value_node = node[idx]
+            name = name_node.astext()
+            if name == 'Status Codes':
+                visitor = StatusVisitor(self.document)
+                value_node.walkabout(visitor)
+                self.endpoint.add_response_codes(visitor.status_info)
+            elif name == 'Request Headers':
+                visitor = HeaderVisitor(self.document)
+                value_node.walkabout(visitor)
+                self.endpoint.add_request_headers(visitor.headers)
+            elif name == 'Response Headers':
+                pass
+            elif name == 'Parameters':
+                visitor = ParameterVisitor(self.document)
+                value_node.walkabout(visitor)
+                self.endpoint.parameters.extend(visitor.parameters)
+            elif name == 'Request JSON Object':
+                pass
+            elif name == 'Request JSON Array of Objects':
+                pass
+            elif name == 'Response JSON Object':
+                pass
+            elif name == 'Response JSON Array of Objects':
+                pass
+            else:
+                self.document.reporter.warning(
+                    'unhandled field type: {}'.format(name), base_node=node)
+            raise nodes.SkipChildren
 
-                    elif name.astext() == 'Request Headers':
-                        for name, spec in _generate_parameters(field[1]):
-                            spec['name'] = name
-                            spec['in'] = 'header'
-                            parameters.append(spec)
 
-                    elif name.astext() == 'Parameters':
-                        for name, spec in _generate_parameters(field[1]):
-                            spec['name'] = name
-                            spec['in'] = 'path'
-                            spec['required'] = True
-                            parameters.append(spec)
+class ParameterVisitor(nodes.SparseNodeVisitor):
+    """Visit a list of parameters and format them."""
 
-                    elif name.astext() == 'Query Parameters':
-                        for name, spec in _generate_parameters(field[1]):
-                            spec['name'] = name
-                            spec['in'] = 'query'
-                            parameters.append(spec)
+    def __init__(self, document):
+        nodes.SparseNodeVisitor.__init__(self, document)
+        self.parameters = []
 
-        for k in tuple(responses.keys()):
-            if not responses[k]:
-                del responses[k]
-        self._swagger_doc.add_path_info(
-            desc_signature['method'], url_template, paragraphs,
-            parameters, responses)
+    def visit_list_item(self, node):
+        """
+        :param docutils.nodes.list_item node:
+        """
+        type_map = {
+            'str': 'string',
+            'int': 'number',
+            'float': 'number',
+            'object': 'object',
+            'dict': 'object',
+        }
 
-        self._current_node = None
+        visitor = ParagraphVisitor(self.document)
+        node[0].walkabout(visitor)
+        tokens = visitor.get_paragraph().split()
+
+        # name (type) -- description
+        idx = tokens.index('--')
+        try:
+            s, e = tokens.index('(', 0, idx), tokens.index(')', 0, idx)
+            name = ' '.join(tokens[:s])
+            type = type_map.get(tokens[s+1]) or 'string'
+        except ValueError:
+            name = ' '.join(tokens[:idx])
+            type = 'string'
+
+        self.parameters.append({'name': name,
+                                'type': type,
+                                'description': ' '.join(tokens[idx + 1:]),
+                                'in': 'path',
+                                'required': True})
+
+        raise nodes.SkipChildren
+
+
+class StatusVisitor(nodes.SparseNodeVisitor):
+    """Visit HTTP status codes and render them."""
+
+    def __init__(self, document):
+        nodes.SparseNodeVisitor.__init__(self, document)
+        self.status_info = {}
+
+    def visit_list_item(self, node):
+        """
+        :param docutils.nodes.list_item node:
+        """
+        # 0: code (' ' reason)?
+        # 1: ' -- '
+        # 2+: description
+        visitor = ParagraphVisitor(self.document)
+        node[0].walkabout(visitor)
+        tokens = visitor.get_paragraph().split()
+        if tokens[0].startswith('['):  # have a link, protect it
+            code = tokens[0][1:]
+            tokens[1] = '[' + tokens[1]
+        else:
+            code = tokens[0]
+        idx = tokens.index('--')
+        reason = ' '.join(tokens[1:idx])
+        description = ' '.join(tokens[idx+1:])
+        self.status_info[code] = {'reason': reason, 'description': description}
+
+
+class ParagraphVisitor(nodes.SparseNodeVisitor):
+    """
+    Renders a paragraph node into GitHub-Flavoured Markdown.
+
+    The result is a list of formatted chunks that you can retrieve
+    from :meth:`get_paragraph`.
+
+    """
+
+    def __init__(self, document):
+        nodes.SparseNodeVisitor.__init__(self, document)
+        self.chunks = []
+        self._stack = []
+
+    def get_paragraph(self):
+        """
+        Retrieve the formatted chunks of text.
+
+        :return: the formatted text as a :class:`str`
+        :rtype: str
+
+        """
+        return ' '.join(' '.join(chunk.strip().split())
+                        for chunk in self.chunks
+                        if chunk.strip())
+
+    def _push_position(self):
+        """Push the current position onto the stack."""
+        self._stack.append(len(self.chunks))
+
+    def _pop_saved_chunks(self):
+        """
+        Pop the chunks that have been collected since the last push.
+
+        :return: the chunks joined as a string
+        :rtype: str
+
+        """
+        start = self._stack.pop()
+        content = ' '.join(self.chunks[start:])
+        del self.chunks[start:]
+        return content
+
+    def visit_Text(self, node):
+        self.chunks.append(node.astext())
+        raise nodes.SkipChildren
+
+    def visit_reference(self, _):
+        self._push_position()
+
+    def depart_reference(self, node):
+        if 'refuri' in node.attributes:
+            content = self._pop_saved_chunks()
+            self.chunks.append('[{}]({})'.format(content,
+                                                 node.attributes['refuri']))
+        else:
+            self._stack.pop()
+
+    def visit_literal(self, _):
+        self._push_position()
+
+    def depart_literal(self, _):
+        self.chunks.append('`{}`'.format(self._pop_saved_chunks()))
+
+    def visit_emphasis(self, _):
+        self._push_position()
+
+    def depart_emphasis(self, _):
+        self.chunks.append('*{}*'.format(self._pop_saved_chunks()))
+
+    def visit_strong(self, _):
+        self._push_position()
+
+    def depart_strong(self, _):
+        self.chunks.append('**{}**'.format(self._pop_saved_chunks()))
+
+
+class HeaderVisitor(nodes.SparseNodeVisitor):
+    """Visit HTTP headers and collect them."""
+
+    def __init__(self, document):
+        nodes.SparseNodeVisitor.__init__(self, document)
+        self.headers = {}
+
+    def visit_list_item(self, node):
+        """
+        :param docutils.nodes.list_item node:
+        """
+        # 0: name
+        # 1: ' -- '
+        # 2: description
+        content = node[0]  # paragraph node
+        # normalize the header name so that words are upper-cased
+        normalized = ' '.join('-'.join(elm.title() for elm in word.split('-'))
+                              for word in content[0].astext().split())
+        if len(content) > 2:
+            first_para = content[2].astext()
+            words = first_para.split()
+            words[0] = words[0].title()
+            paragraphs = [' '.join(words)]
+            paragraphs.extend(t.astext().replace('\n', ' ').strip()
+                              for t in content[3:])
+            description = ' '.join(paragraphs)
+        else:
+            description = ''
+
+        self.headers[normalized] = description
 
 
 def _generate_debug_tree(node):
-    n = {'type': str(type(node)),
+    n = {'type': node.__class__.__name__,
          'attributes': node.attributes if hasattr(node, 'attributes') else {},
          'children': [_generate_debug_tree(x) for x in node.children]}
     if isinstance(node, nodes.Text):
         n['value'] = str(node)
     return n
-
-
-def _render_paragraph(paragraph):
-    """
-    :param nodes.paragraph paragraph:
-    :returns: str
-    """
-    lines = [t.astext() for t in paragraph.children
-             if isinstance(t, nodes.Text)]
-    return '\n\n'.join(lines)
-
-
-def _render_request_document(body):
-    """
-    :param nodes.field_body body:
-    :rtype: dict|NoneType
-    """
-    if len(body.children) > 1 or not isinstance(body[0], nodes.bullet_list):
-        return None
 
 
 def _render_response_information(body):
@@ -250,63 +417,6 @@ def _render_response_information(body):
     return response_obj
 
 
-def _generate_status_codes(body):
-    """
-    :param nodes.field_body body:
-    :returns: :data:`tuple` of (code, reason, description)
-    :rtype: tuple
-    """
-    if len(body.children) > 1 or not isinstance(body[0], nodes.bullet_list):
-        return
-
-    bullet_list = body[0]
-
-    for list_item in bullet_list.children:
-        assert isinstance(list_item[0], nodes.paragraph)
-        assert len(list_item.children) == 1
-
-        para = list_item[0]
-        assert isinstance(para, nodes.paragraph)
-        assert len(para.children) >= 2
-
-        # 0: code ' ' reason
-        # 1: ' -- '
-        # 2*: description
-        code, _, reason = para.children[0].astext().partition(' ')
-        if not reason:
-            try:
-                reason = http_client.responses.get(int(reason))
-            except (KeyError, TypeError, ValueError):
-                pass
-        description = ''.join(t.astext() for t in para.children[2:])
-        if reason:
-            description = reason + '\n\n' + description
-        yield code, _, description
-
-
-def _generate_parameters(body):
-    """
-    :param nodes.field_body body:
-    :returns: :data:`tuple` of (name, dict)
-    :rtype: tuple
-    """
-    bullet_list = body[0]
-
-    for list_item in bullet_list.children:
-        assert isinstance(list_item, nodes.list_item)
-        assert len(list_item.children) == 1
-
-        para = list_item[0]
-        assert isinstance(para, nodes.paragraph)
-
-        obj_info = _parsed_typed_object(para)
-        if obj_info:
-            yield obj_info['name'], {
-                'type': obj_info['type'],
-                'description': obj_info['description'],
-            }
-
-
 def _parsed_typed_object(paragraph):
     """
     Parses a typed-object description like ``name (type) -- description``.
@@ -334,7 +444,8 @@ def _parsed_typed_object(paragraph):
         t = 'string'
         desc_start = 2
 
-    description = '\n\n'.join(n.astext() for n in paragraph[desc_start:])
+    description = '\n\n'.join(n.astext().replace('\n', ' ')
+                              for n in paragraph[desc_start:])
 
     return {
         'name': name,
@@ -360,50 +471,3 @@ def _convert_url(url):
 
     raise RuntimeError('failed to convert {} to a URL Template '
                        'after {} tries'.format(start_url, attempt))
-
-
-class SwaggerDocument(object):
-
-    def __init__(self):
-        super(SwaggerDocument, self).__init__()
-        self._paths = {}
-
-    def get_document(self, config):
-        """
-        :param sphinx.config.Config config: project-level configuration
-        :return: swagger document as a :class`dict`
-        :rtype: dict
-        """
-        info = {
-            'title': config.project,
-            'version': config.version,
-        }
-        if config.swagger_description:
-            info['description'] = config.swagger_description
-        else:
-            try:
-                info['description'] = config.html_theme_options['description']
-            except (AttributeError, KeyError):
-                info['description'] = ''
-        if config.swagger_license:
-            info['license'] = config.swagger_license
-
-        return {'swagger': '2.0',
-                'info': info,
-                'host': 'localhost:8000',
-                'basePath': '/',
-                'paths': copy.deepcopy(self._paths)}
-
-    def add_path_info(self, method, url_template, description,
-                      parameters, responses):
-        path_info = self._paths.setdefault(url_template, {})
-        path_info[method] = {}
-        if len(description) > 1 and len(description[0]) < 120:
-            path_info[method]['summary'] = description.pop(0)
-        path_info[method]['description'] = '\n\n'.join(description)
-        if parameters:
-            path_info[method]['parameters'] = copy.deepcopy(parameters)
-        if responses:
-            path_info[method]['responses'] = copy.deepcopy(responses)
-        else:
-            path_info[method]['responses'] = {'default': {'description': ''}}

--- a/sphinxswagger/writer.py
+++ b/sphinxswagger/writer.py
@@ -378,10 +378,13 @@ class SwaggerDocument(object):
             'title': config.project,
             'version': config.version,
         }
-        try:
-            info['description'] = config.html_theme_options['description']
-        except (AttributeError, KeyError):
-            info['description'] = ''
+        if config.swagger_description:
+            info['description'] = config.swagger_description
+        else:
+            try:
+                info['description'] = config.html_theme_options['description']
+            except (AttributeError, KeyError):
+                info['description'] = ''
         if config.swagger_license:
             info['license'] = config.swagger_license
 


### PR DESCRIPTION
This PR is pretty much a rewrite with the addition of a setup tools `swagger` command.  It makes generating docs in a CI environment a lot easier.  The rewrite was a pivot from interpreting each of the formatted structures inline in a rigid manner to using docutils visitors.  This should make things more resilient against changes in the httpdomain library.