### PR TITLE
Fix parameter processing.

### DIFF
--- a/requires/installation.txt
+++ b/requires/installation.txt
@@ -1,2 +1,2 @@
 Sphinx>=1.4,<2
-sphinxcontrib-httpdomain==1.5.0
+sphinxcontrib-httpdomain>=1.5.0

--- a/setup.py
+++ b/setup.py
@@ -42,4 +42,9 @@ setuptools.setup(
         'Programming Language :: Python :: 3.4',
         'Framework :: Sphinx :: Extension',
     ],
+    entry_points={
+        'distutils.commands': [
+            'swagger = sphinxswagger.command:BuildSwagger',
+        ],
+    },
 )


### PR DESCRIPTION
I upgraded to a newer version of `sphinxcontrib-httpdomain` and it looks like the representation of parameters has changed ever so slightly.  Instead of using two hyphens (`--`) to separate the name and type from the description, a en-dash (`–`) is now used.  This PR accounts for the change.